### PR TITLE
Add endpoint to fetch forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem 'dotenv', '~> 2.1', '>= 2.1.1'
 gem 'webmock', '~> 2.1'
+gem 'vcr', '~> 3.0', '>= 3.0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dotenv', '~> 2.1', '>= 2.1.1'
+gem 'webmock', '~> 2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in convertkit-ruby.gemspec
 gemspec
+
+gem 'dotenv', '~> 2.1', '>= 2.1.1'

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ API actions are available as methods on the client object. Currently, the Conver
 | Add subscriber to sequence | `#add_subscriber_to_sequence(sequence_id, email, options = {})`|
 | List tags               | `#tags`                      |
 | Add subscriber to tag   | `#add_subscriber_to_tag(tag_id, email, options = {})`|
+| List forms              | `#forms`                     |
 
 **Note:** We do not have complete API coverage yet. If we are missing an API method that you need to use in your application, please file an issue and/or open a pull request. [See the official API documentation](http://kb.convertkit.com/article/api-documentation-v3/) for a complete API reference.
 

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,14 @@
 
 require "bundler/setup"
 require "convertkit"
+require "dotenv"
+
+Dotenv.load(".env.local")
+
+Convertkit.configure do |config|
+  config.api_secret = ENV["API_SECRET"]
+  config.api_key = ENV["API_KEY"]
+end
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/fixtures/vcr_cassettes/forms.yml
+++ b/fixtures/vcr_cassettes/forms.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.convertkit.com/v3/forms?api_key=<API_KEY>&api_secret=<API_SECRET>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Convertkit-Ruby v0.0.2
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"2d9600a1c415ac1e19ee2465fe41e8cc"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - XSRF-TOKEN=a1hcmaYVulN4QDrGoRSz6Y51cfjXMdmyJ66kyX3dPECeDZnhdd9AOW%2BBSwx3ppH5jwi4MQ%2FuR5kIfxCRlDy8dg%3D%3D;
+        path=/; secure
+      - _mailapp_session=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiJTMwYzJkNTcxMWViZjNhMmVjYTIxZjI0NDE0NGZiYjY2BjsAVEkiEF9jc3JmX3Rva2VuBjsARkkiMTlWWEZlTlBLK21vWHdYSEsxcklpRUFGOXljblkzNTRyTDlHMFdPbmhnRFk9BjsARg%3D%3D--f0567bcf5195953cceab58959153298cdae4426b;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - 6816358f-f95d-4374-ada6-9afe67a9717b
+      X-Runtime:
+      - '0.022329'
+      Vary:
+      - Accept-Encoding, Origin
+      Date:
+      - Fri, 02 Dec 2016 22:20:57 GMT
+      X-Rack-Cache:
+      - miss
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"forms":[{"id":133233,"name":"Did you like this post","created_at":"2016-12-01T17:25:23Z","type":"embed","url":"https://app.convertkit.com/landing_pages/133233","embed_js":"https://api.convertkit.com/v3/forms/133233.js?api_key=<API_KEY>","embed_url":"https://api.convertkit.com/v3/forms/133233.html?api_key=<API_KEY>","title":"Did
+        you like this post?","description":"\u003Cp\u003ESubscribe to my newsletter
+        and start every week with a new interesting post! \u003C/p\u003E","sign_up_button_text":"Subscribe","success_message":"Success!
+        Now check your email to confirm your subscription."}]}'
+    http_version: 
+  recorded_at: Fri, 02 Dec 2016 22:21:29 GMT
+recorded_with: VCR 3.0.3

--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -1,6 +1,7 @@
 require "convertkit/client/sequences"
 require "convertkit/client/subscribers"
 require "convertkit/client/tags"
+require "convertkit/client/forms"
 require "faraday"
 require "faraday_middleware"
 require "json"
@@ -10,6 +11,7 @@ module Convertkit
     include Subscribers
     include Sequences
     include Tags
+    include Forms
 
     attr_accessor :api_secret, :api_key
 

--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -36,6 +36,8 @@ module Convertkit
         f.params['api_secret'] = api_secret if api_secret
         f.params['api_key'] = api_key if api_key
 
+#        f.proxy URI('http://localhost:8888')
+
         f.response :json, content_type: /\bjson$/
       end
     end

--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -36,8 +36,6 @@ module Convertkit
         f.params['api_secret'] = api_secret if api_secret
         f.params['api_key'] = api_key if api_key
 
-#        f.proxy URI('http://localhost:8888')
-
         f.response :json, content_type: /\bjson$/
       end
     end

--- a/lib/convertkit/client/forms.rb
+++ b/lib/convertkit/client/forms.rb
@@ -1,0 +1,9 @@
+module Convertkit
+  class Client
+    module Forms
+      def forms
+        connection.get("forms")
+      end
+    end
+  end
+end

--- a/lib/convertkit/client/forms.rb
+++ b/lib/convertkit/client/forms.rb
@@ -2,7 +2,7 @@ module Convertkit
   class Client
     module Forms
       def forms
-        connection.get("forms")
+        connection.get("forms").body["forms"]
       end
     end
   end

--- a/spec/convertkit/client/forms_spec.rb
+++ b/spec/convertkit/client/forms_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+module Convertkit
+  class Client
+    describe Sequences do
+      before do
+        @client = Convertkit::Client.new
+      end
+
+      describe "#forms" do
+        it "fetches forms", :vcr do
+          #stub = stub_request(:get, "https://api.convertkit.com/v3/forms")
+          VCR.use_cassette 'forms' do
+            @forms = @client.forms
+          end
+          #expect(stub).to have_been_made.once
+        end
+      end
+    end
+  end
+end

--- a/spec/convertkit/client/forms_spec.rb
+++ b/spec/convertkit/client/forms_spec.rb
@@ -9,11 +9,11 @@ module Convertkit
 
       describe "#forms" do
         it "fetches forms", :vcr do
-          #stub = stub_request(:get, "https://api.convertkit.com/v3/forms")
           VCR.use_cassette 'forms' do
             @forms = @client.forms
+            expect(@forms.count).to eq(1)
+            expect(@forms.first["id"]).to eq(133233)
           end
-          #expect(stub).to have_been_made.once
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,23 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'convertkit'
 require "dotenv"
 Dotenv.load(".env.local")
+
+require 'webmock/rspec'
+require 'vcr'
+
+Convertkit.configure do |config|
+  config.api_secret = ENV["API_SECRET"]
+  config.api_key = ENV["API_KEY"]
+end
+
+VCR.configure do |config|
+  config.cassette_library_dir = "fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data("<API_SECRET>") { ENV["API_SECRET"] }
+  config.filter_sensitive_data("<API_KEY>") { ENV["API_KEY"] }
+  config.allow_http_connections_when_no_cassette = true
+end
+
+WebMock.allow_net_connect!
+
+


### PR DESCRIPTION
* Adds VCR to stub the HTTP response for the forms endpoint, other tests remain unchanged for now
* The `forms` method returns nil in case of error. It's not great but it's a lot more convenient than manipulating Faraday responses. In my cases it was `client.forms.body["forms"]`. I'm ok to change that if you have a better idea. Maybe using [Sawyer](https://github.com/lostisland/sawyer)?

Let me know what you think! 😄 
