### PR TITLE
Add unsubscribe endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ API actions are available as methods on the client object. Currently, the Conver
 | List tags               | `#tags`                      |
 | Add subscriber to tag   | `#add_subscriber_to_tag(tag_id, email, options = {})`|
 | List forms              | `#forms`                     |
+| Unsubscribe             | `#unsubscribe(email)`        |
 
 **Note:** We do not have complete API coverage yet. If we are missing an API method that you need to use in your application, please file an issue and/or open a pull request. [See the official API documentation](http://kb.convertkit.com/article/api-documentation-v3/) for a complete API reference.
 

--- a/lib/convertkit/client/subscribers.rb
+++ b/lib/convertkit/client/subscribers.rb
@@ -8,6 +8,12 @@ module Convertkit
       def subscriber(subscriber_id)
         connection.get("subscribers/#{subscriber_id}")
       end
+
+      def unsubscribe(email)
+        connection.put("unsubscribe") do |f|
+          f.params['email'] = email
+        end
+      end
     end
   end
 end

--- a/spec/convertkit/client/subscribers_spec.rb
+++ b/spec/convertkit/client/subscribers_spec.rb
@@ -29,6 +29,18 @@ module Convertkit
           expect(r.body).to_not eql({"error"=>"Not Found", "message"=>"The entity you were trying to find doesn't exist"})
         end
       end
+
+      describe "#unsubscribe" do
+        it "sends the right request" do
+          tag_id = ENV['TAG_ID']
+          email = "crt-subscribers+#{Time.now.to_i}@example.com"
+          @client.add_subscriber_to_tag(tag_id, email)
+          
+          r = @client.unsubscribe(email)
+          expect(r.success?).to be_truthy
+          expect(r.body).to_not eql({"error"=>"Not Found", "message"=>"The entity you were trying to find doesn't exist"})
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds an endpoint for ConvertKit's unsubscribe API call. Triggering this endpoint unsubscribes the given subscriber from all forms, tags, and sequences.