### PR TITLE
Allow to use newer versions of Faraday

### DIFF
--- a/convertkit-ruby.gemspec
+++ b/convertkit-ruby.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "dotenv", "~> 2.1"
 
-  spec.add_runtime_dependency "faraday", "~> 0.9.2"
+  spec.add_runtime_dependency "faraday", ">= 0.9.2"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.10.0"
   spec.add_runtime_dependency "json", '>= 1.8.3'
 end


### PR DESCRIPTION
This is needed to make this gem compatible with other gems. In our case we use the stripe gem which requires faraday (~> 0.10).