### PR TITLE
Add error handling

### DIFF
--- a/lib/convertkit/client.rb
+++ b/lib/convertkit/client.rb
@@ -4,9 +4,7 @@ require "convertkit/client/forms"
 require "convertkit/client/sequences"
 require "convertkit/client/subscribers"
 require "convertkit/client/tags"
-require "faraday"
-require "faraday_middleware"
-require "json"
+require "convertkit/connection"
 
 module Convertkit
   class Client
@@ -24,24 +22,8 @@ module Convertkit
       @api_key = api_key || Convertkit.configuration.api_key
     end
 
-    def content_type
-      'application/vnd.api+json'
-    end
-
     def connection
-      @connection ||= Faraday.new do |f|
-        f.url_prefix = "https://api.convertkit.com/v3/"
-        f.adapter :net_http
-
-        f.headers['User-Agent'] = "Convertkit-Ruby v#{Convertkit::VERSION}"
-        f.headers['Content-Type'] = content_type
-        f.headers['Accept'] = "*/*"
-
-        f.params['api_secret'] = api_secret if api_secret
-        f.params['api_key'] = api_key if api_key
-
-        f.response :json, content_type: /\bjson$/
-      end
+      @connection ||= Connection.new(api_key: api_key, api_secret: api_secret)
     end
   end
 end

--- a/lib/convertkit/connection.rb
+++ b/lib/convertkit/connection.rb
@@ -1,3 +1,4 @@
+require "convertkit/errors"
 require "faraday"
 require "faraday_middleware"
 require "json"
@@ -6,7 +7,7 @@ module Convertkit
   class Connection
     attr_reader :http_connection
 
-    def initialize(api_key:, api_secret:)
+    def initialize(api_key: nil, api_secret: nil)
       @http_connection = faraday_connection(api_key, api_secret)
     end
 
@@ -32,12 +33,8 @@ module Convertkit
 
     private
 
-    def request(method, *args, &blk)
-      http_connection.public_send(method, *args, &blk)
-    end
-
     def faraday_connection(api_key, api_secret)
-      @_faraday_connection ||= Faraday.new do |f|
+      Faraday.new do |f|
         f.url_prefix = "https://api.convertkit.com/v3/"
         f.adapter :net_http
 
@@ -49,6 +46,35 @@ module Convertkit
         f.params['api_key'] = api_key if api_key
 
         f.response :json, content_type: /\bjson$/
+      end
+    end
+
+    def request(method, *args, &blk)
+      begin
+        response = http_connection.public_send(method, *args, &blk)
+      rescue Faraday::Error => e
+        raise ConnectionError.new(e)
+      end
+
+      unless response.success?
+        handle_error_response(response)
+      end
+
+      response
+    end
+
+    def handle_error_response(response)
+      case response.status
+      when 401
+        raise AuthorizationError.new(response.body)
+      when 422
+        raise UnprocessableEntityError.new(response.body)
+      when 429
+        raise TooManyRequestsError.new(response.body)
+      when 500..599
+        raise ServerError.new(response.body)
+      else
+        raise UnknownError.new(response.body)
       end
     end
   end

--- a/lib/convertkit/connection.rb
+++ b/lib/convertkit/connection.rb
@@ -1,0 +1,55 @@
+require "faraday"
+require "faraday_middleware"
+require "json"
+
+module Convertkit
+  class Connection
+    attr_reader :http_connection
+
+    def initialize(api_key:, api_secret:)
+      @http_connection = faraday_connection(api_key, api_secret)
+    end
+
+    def content_type
+      "application/vnd.api+json"
+    end
+
+    def get(*args, &blk)
+      request(:get, *args, &blk)
+    end
+
+    def post(*args, &blk)
+      request(:post, *args, &blk)
+    end
+
+    def put(*args, &blk)
+      request(:put, *args, &blk)
+    end
+
+    def delete(*args, &blk)
+      request(:delete, *args, &blk)
+    end
+
+    private
+
+    def request(method, *args, &blk)
+      http_connection.public_send(method, *args, &blk)
+    end
+
+    def faraday_connection(api_key, api_secret)
+      @_faraday_connection ||= Faraday.new do |f|
+        f.url_prefix = "https://api.convertkit.com/v3/"
+        f.adapter :net_http
+
+        f.headers['User-Agent'] = "Convertkit-Ruby v#{Convertkit::VERSION}"
+        f.headers['Content-Type'] = content_type
+        f.headers['Accept'] = "*/*"
+
+        f.params['api_secret'] = api_secret if api_secret
+        f.params['api_key'] = api_key if api_key
+
+        f.response :json, content_type: /\bjson$/
+      end
+    end
+  end
+end

--- a/lib/convertkit/errors.rb
+++ b/lib/convertkit/errors.rb
@@ -1,0 +1,10 @@
+module Convertkit
+  class Error < StandardError; end
+
+  class AuthorizationError < Error; end
+  class ConnectionError < Error; end
+  class ServerError < Error; end
+  class TooManyRequestsError < Error; end
+  class UnknownError < Error; end
+  class UnprocessableEntityError < Error; end
+end

--- a/spec/convertkit/client_spec.rb
+++ b/spec/convertkit/client_spec.rb
@@ -16,19 +16,5 @@ module Convertkit
         expect(@client.api_key).to eq(ENV["API_KEY"])
       end
     end
-
-    context "authorization" do
-      it "uses api key" do
-        @client.api_secret = nil
-
-        expect(@client.connection.params["api_key"]).to eq(ENV["API_KEY"])
-      end
-
-      it "uses api secret" do
-        @client.api_key = nil
-
-        expect(@client.connection.params["api_secret"]).to eq(ENV["API_SECRET"])
-      end
-    end
   end
 end

--- a/spec/convertkit/connection_spec.rb
+++ b/spec/convertkit/connection_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+module Convertkit
+  describe Connection do
+    describe "#initialize" do
+      it "uses api key" do
+        api_key = "api_key"
+        connection = Connection.new(api_key: api_key)
+
+        expect(connection.http_connection.params["api_key"]).to eq(api_key)
+      end
+
+      it "uses api secret" do
+        api_secret = "api_secret"
+        connection = Connection.new(api_secret: api_secret)
+
+        expect(connection.http_connection.params["api_secret"]).to eq(api_secret)
+      end
+    end
+
+    describe "error handling" do
+      before do
+        @connection = Connection.new(api_key: "api_key")
+      end
+
+      it "handles 401 errors" do
+        stub_request(:get, /.*/).to_return(status: 401)
+
+        expect { @connection.get("account") }.to raise_error(AuthorizationError)
+      end
+
+      it "handles 422 errors" do
+        stub_request(:get, /.*/).to_return(status: 422)
+
+        expect { @connection.get("account") }.to raise_error(UnprocessableEntityError)
+      end
+
+      it "handles 429 errors" do
+        stub_request(:get, /.*/).to_return(status: 429)
+
+        expect { @connection.get("account") }.to raise_error(TooManyRequestsError)
+      end
+
+      it "handles 500 errors" do
+        stub_request(:get, /.*/).to_return(status: 500)
+
+        expect { @connection.get("account") }.to raise_error(ServerError)
+      end
+
+      it "handles uknown errors" do
+        stub_request(:get, /.*/).to_return(status: 403)
+
+        expect { @connection.get("account") }.to raise_error(UnknownError)
+      end
+
+      it "handles connection issues" do
+        stub_request(:get, /.*/).to_timeout
+
+        expect { @connection.get("account") }.to raise_error(ConnectionError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Raise errors for all non 2xx responses and for all connection errors. All error classes inherit from `Convertkit::Error` which can be use to catch all API issues.

Fixes https://github.com/HookOps/convertkit-ruby/issues/14.